### PR TITLE
Add preferred_maintenance_window variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
   deletion_protection       = var.deletion_protection
   backup_retention_period   = var.backup_retention_period
   preferred_backup_window   = var.preferred_backup_window
+  preferred_maintenance_window = var.preferred_maintenance_window
 
   db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
 

--- a/variables.tf
+++ b/variables.tf
@@ -108,5 +108,11 @@ variable "backup_retention_period" {
 variable "preferred_backup_window" {
   type        = string
   default     = null
-  description = "The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter. Time in UTC. Uses aws_rds_cluster default. E.g. 04:00-09:00"
+  description = "The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter. Time in UTC. Cannot overlap maintenance time. Uses aws_rds_cluster default. E.g. 04:00-09:00"
+}
+
+variable "preferred_maintenance_window" {
+  type        = string
+  default     = null
+  description = "The weekly time range during which system maintenance can occur, in (UTC) e.g., wed:04:00-wed:04:30. Cannot overlap backup time. Uses aws_rds_cluster default."
 }


### PR DESCRIPTION
Since we can specify the backup time we also need to be able to specify the maintenance time to avoid them overlapping.